### PR TITLE
Shard between different hosts on demand

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -48,8 +48,9 @@ class Statsd
     add_host(host, port, key)
   end
 
-  def add_host(host, port, key = nil)
-    @hosts << Host.new(host, port, key)
+  def add_host(host, port = nil, key = nil)
+    host, port = host.split(':') if host.include?(':')
+    @hosts << Host.new(host, port.to_i, key)
   end
 
   # Sends an increment (count = 1) for the given stat to the statsd server.

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -119,7 +119,7 @@ class Statsd
     sampled(sample_rate) do
       prefix = "#{@namespace}." unless @namespace.nil?
       stat = stat.to_s.gsub('::', '.').gsub(RESERVED_CHARS_REGEX, '_')
-      msg = "#{prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}")
+      msg = "#{prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}"
       send_to_socket(select_host(stat), msg)
     end
   end

--- a/statsd-ruby.gemspec
+++ b/statsd-ruby.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{statsd-ruby}
-  s.version = "0.3.0.github.4"
+  s.version = "0.3.0.github.5"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Rein Henrichs"]

--- a/statsd-ruby.gemspec
+++ b/statsd-ruby.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{statsd-ruby}
-  s.version = "0.3.0.github.3"
+  s.version = "0.3.0.github.4"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Rein Henrichs"]


### PR DESCRIPTION
As requested, this will fix Ruby clients so they can shard between several StatsD hosts. I did not break the API so this should be a drop-in replacement everywhere.

cc @jssjr @jnewland 