### PR TITLE
Add histogram method

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -109,6 +109,12 @@ class Statsd
     result
   end
 
+  # Sends a histogram measurement for the given stat to the statsd server. The
+  # sample_rate determines what percentage of the time this report is sent. The
+  # statsd server then uses the sample_rate to correctly track the average
+  # for the stat.
+  def histogram(stat, value, sample_rate=1); send stat, value, 'h', sample_rate end
+
   private
 
   def sampled(sample_rate)

--- a/statsd-ruby.gemspec
+++ b/statsd-ruby.gemspec
@@ -5,7 +5,7 @@
 
 Gem::Specification.new do |s|
   s.name = %q{statsd-ruby}
-  s.version = "0.3.0.github.5"
+  s.version = "0.4.0.github"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Rein Henrichs"]


### PR DESCRIPTION
Timings are recorded as a histogram but the unit is implied as ms. This exposes the histogram collection for arbitrary stats without implying a unit should we ever change the handling of timings in the aggregator.