### PR TITLE
Avoid loading openssl + securerandom unless needed

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -1,5 +1,4 @@
 require 'socket'
-require 'time'
 require 'zlib'
 
 # = Statsd: A Statsd client (https://github.com/etsy/statsd)

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -1,5 +1,3 @@
-require 'openssl'
-require 'securerandom'
 require 'socket'
 require 'time'
 require 'zlib'
@@ -31,9 +29,6 @@ class Statsd
 
   #characters that will be replaced with _ in stat names
   RESERVED_CHARS_REGEX = /[\:\|\@]/
-
-  # Digest object as a constant
-  SHA256 = OpenSSL::Digest::SHA256.new
 
   class << self
     # Set to any standard logger instance (including stdlib's Logger) to enable
@@ -150,9 +145,20 @@ class Statsd
   end
 
   def signed_payload(key, message)
+    sha256 = Statsd.setup_openssl
     payload = timestamp + nonce + message
-    signature = OpenSSL::HMAC.digest(SHA256, key, payload)
+    signature = OpenSSL::HMAC.digest(sha256, key, payload)
     signature + payload
+  end
+
+  # defer loading openssl and securerandom unless needed. this shaves ~10ms off
+  # of baseline require load time for environments that don't require message signing.
+  def self.setup_openssl
+    @sha256 ||= begin
+      require 'securerandom'
+      require 'openssl'
+      OpenSSL::Digest::SHA256.new
+    end
   end
 
   def timestamp


### PR DESCRIPTION
I've been profiling boot time for some scripts that are short-lived / high throughput and noticed that requiring the openssl lib (brought in via statsd.rb) can add a pretty massive 30ms user+sys cpu overhead:

```
Thread ID: 69933375328960
Fiber ID: 69933379015820
Total: 0.049605
Sort by: self_time

 %self      total      self      wait     child     calls  name
 12.78      0.008     0.006     0.000     0.002        1   RequireProf#require:openssl.so 
  6.11      0.005     0.003     0.000     0.002        1   RequireProf#require:socket 
  6.10      0.003     0.003     0.000     0.000        1   RequireProf#require:zlib 
  5.76      0.030     0.003     0.000     0.027        2   RequireProf#require:openssl 
  5.61      0.003     0.003     0.000     0.000        1   RequireProf#require:date_core 
  5.44      0.003     0.003     0.000     0.000        1   RequireProf#require:stringio 
  5.18      0.008     0.003     0.000     0.006        1   RequireProf#require:time 
  4.97      0.002     0.002     0.000     0.000        1   RequireProf#require:fcntl 
  4.48      0.005     0.002     0.000     0.003        1   RequireProf#require:openssl/config 
  4.22      0.002     0.002     0.000     0.000        1   RequireProf#require:socket.so 
  4.01      0.002     0.002     0.000     0.000        1   RequireProf#require:openssl/x509 
  3.88      0.002     0.002     0.000     0.000        1   RequireProf#require:openssl/buffering 
  3.85      0.007     0.002     0.000     0.005        1   RequireProf#require:openssl/ssl 
  3.61      0.003     0.002     0.000     0.001        1   RequireProf#require:securerandom 
  2.99      0.006     0.001     0.000     0.004        1   RequireProf#require:date 
  2.94      0.002     0.001     0.000     0.000        1   RequireProf#require:openssl/digest 
  2.93      0.002     0.001     0.000     0.000        1   RequireProf#require:openssl/cipher 
  2.87      0.001     0.001     0.000     0.000        1   RequireProf#require:digest.so 
  2.80      0.001     0.001     0.000     0.000        1   RequireProf#require:openssl/bn 
  2.53      0.001     0.001     0.000     0.000        1   RequireProf#require:date/format 
  2.45      0.050     0.001     0.000     0.048        1   RequireProf#require:statsd 
... snip everything < 1ms ...
```

This PR avoids loading the openssl and securerandom libs unless a signing key was provided. I've also removed the 'time' require. The core Time class has Time.now built in. Explicitly requiring 'time' brings in a bunch of formatting functions like Time#iso8601, stuff we don't here.

/cc @jssjr, @tmm1, @vmg, @github/perf