### PR TITLE
Use addrinfo to find correct address family to create socket with

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -18,8 +18,9 @@ class Statsd
     attr_reader :key, :sock
 
     def initialize(address, port, key = nil)
-      @sock = UDPSocket.new
-      @sock.connect(address, port)
+      addrinfo = Addrinfo.ip(address)
+      @sock = UDPSocket.new(addrinfo.pfamily)
+      @sock.connect(addrinfo.ip_address, port)
       @key = key
     end
 


### PR DESCRIPTION
The BSD sockets API requires that sockets are created with a specific protocol family up front. Ruby's `UDPSocket` uses `PF_INET` by default, but this doesn't work when we're trying to connect to an IPv6 address.

This pull request changes the `RubyUdpClient` class to use `Addrinfo` to resolve the address beforehand so we can create the socket with `PF_INET6` if we're given an IPv6 address.

cc @vmg @dbussink 