### PR TITLE
Reduce allocations when sending metrics

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -40,6 +40,11 @@ class Statsd
   #characters that will be replaced with _ in stat names
   RESERVED_CHARS_REGEX = /[\:\|\@]/
 
+  COUNTER_TYPE = "c".freeze
+  TIMING_TYPE = "ms".freeze
+  GAUGE_TYPE = "g".freeze
+  HISTOGRAM_TYPE = "h".freeze
+
   def initialize(client_class = nil)
     @shards = []
     @client_class = client_class || RubyUdpClient
@@ -74,7 +79,7 @@ class Statsd
   # @param [String] stat stat name
   # @param [Integer] count count
   # @param [Integer] sample_rate sample rate, 1 for always
-  def count(stat, count, sample_rate=1); send stat, count, 'c', sample_rate end
+  def count(stat, count, sample_rate=1); send stat, count, COUNTER_TYPE, sample_rate end
 
   # Sends an arbitary gauge value for the given stat to the statsd server.
   #
@@ -83,7 +88,7 @@ class Statsd
   # @example Report the current user count:
   #   $statsd.gauge('user.count', User.count)
   def gauge(stat, value)
-    send stat, value, 'g'
+    send stat, value, GAUGE_TYPE
   end
 
   # Sends a timing (in ms) for the given stat to the statsd server. The
@@ -94,7 +99,7 @@ class Statsd
   # @param stat stat name
   # @param [Integer] ms timing in milliseconds
   # @param [Integer] sample_rate sample rate, 1 for always
-  def timing(stat, ms, sample_rate=1); send stat, ms, 'ms', sample_rate end
+  def timing(stat, ms, sample_rate=1); send stat, ms, TIMING_TYPE, sample_rate end
 
   # Reports execution time of the provided block using {#timing}.
   #
@@ -115,7 +120,7 @@ class Statsd
   # sample_rate determines what percentage of the time this report is sent. The
   # statsd server then uses the sample_rate to correctly track the average
   # for the stat.
-  def histogram(stat, value, sample_rate=1); send stat, value, 'h', sample_rate end
+  def histogram(stat, value, sample_rate=1); send stat, value, HISTOGRAM_TYPE, sample_rate end
 
   private
 

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -141,7 +141,19 @@ class Statsd
       stat = stat.to_s.dup
       stat.gsub!(COLON_COLON_REGEX, ".".freeze)
       stat.gsub!(RESERVED_CHARS_REGEX, "_".freeze)
-      msg = "#{@prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}"
+
+      msg = ""
+      msg << @prefix
+      msg << stat
+      msg << ":".freeze
+      msg << delta.to_s
+      msg << "|".freeze
+      msg << type
+      if sample_rate < 1
+        msg << "|@".freeze
+        msg << sample_rate.to_s
+      end
+
       shard = select_shard(stat)
       shard.send(shard.key ? signed_payload(shard.key, msg) : msg)
     end

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -45,8 +45,6 @@ class Statsd
   #characters that will be replaced with _ in stat names
   RESERVED_CHARS_REGEX = /[\:\|\@]/
 
-  COLON_COLON_REGEX = /::/
-
   COUNTER_TYPE = "c".freeze
   TIMING_TYPE = "ms".freeze
   GAUGE_TYPE = "g".freeze
@@ -139,7 +137,7 @@ class Statsd
   def send(stat, delta, type, sample_rate=1)
     sampled(sample_rate) do
       stat = stat.to_s.dup
-      stat.gsub!(COLON_COLON_REGEX, ".".freeze)
+      stat.gsub!(/::/, ".".freeze)
       stat.gsub!(RESERVED_CHARS_REGEX, "_".freeze)
 
       msg = ""

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -139,8 +139,8 @@ class Statsd
   def send(stat, delta, type, sample_rate=1)
     sampled(sample_rate) do
       stat = stat.to_s.dup
-      stat.gsub!(COLON_COLON_REGEX, '.')
-      stat.gsub!(RESERVED_CHARS_REGEX, '_')
+      stat.gsub!(COLON_COLON_REGEX, ".".freeze)
+      stat.gsub!(RESERVED_CHARS_REGEX, "_".freeze)
       msg = "#{@prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}"
       shard = select_shard(stat)
       shard.send(shard.key ? signed_payload(shard.key, msg) : msg)

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -136,7 +136,9 @@ class Statsd
 
   def send(stat, delta, type, sample_rate=1)
     sampled(sample_rate) do
-      stat = stat.to_s.gsub('::', '.').gsub(RESERVED_CHARS_REGEX, '_')
+      stat = stat.to_s.dup
+      stat.gsub!('::', '.')
+      stat.gsub!(RESERVED_CHARS_REGEX, '_')
       msg = "#{@prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}"
       shard = select_shard(stat)
       shard.send(shard.key ? signed_payload(shard.key, msg) : msg)

--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -45,6 +45,8 @@ class Statsd
   #characters that will be replaced with _ in stat names
   RESERVED_CHARS_REGEX = /[\:\|\@]/
 
+  COLON_COLON_REGEX = /::/
+
   COUNTER_TYPE = "c".freeze
   TIMING_TYPE = "ms".freeze
   GAUGE_TYPE = "g".freeze
@@ -137,7 +139,7 @@ class Statsd
   def send(stat, delta, type, sample_rate=1)
     sampled(sample_rate) do
       stat = stat.to_s.dup
-      stat.gsub!('::', '.')
+      stat.gsub!(COLON_COLON_REGEX, '.')
       stat.gsub!(RESERVED_CHARS_REGEX, '_')
       msg = "#{@prefix}#{stat}:#{delta}|#{type}#{'|@' << sample_rate.to_s if sample_rate < 1}"
       shard = select_shard(stat)


### PR DESCRIPTION
These changes get rid of 8 String allocations per recorded metric. (It might also save some Regexp allocations but I'm not totally sure yet.) That's not a lot, but when you record a lot of metrics it adds up.

/cc @github/perf @vmg @charliesome @brianmario