### PR TITLE
Add #batch method for backwards compatibility

### DIFF
--- a/lib/statsd.rb
+++ b/lib/statsd.rb
@@ -184,6 +184,12 @@ class Statsd
   # for the stat.
   def histogram(stat, value, sample_rate=1); send stat, value, HISTOGRAM_TYPE, sample_rate end
 
+  # Provided for backwards compatibility to systems that expect a batch method.
+  # Buffering will transparently be used if its enabled, otherwise this is a noop.
+  def batch
+    yield self
+  end
+
   private
   def sampled(sample_rate)
     yield unless sample_rate < 1 and rand > sample_rate

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -127,6 +127,14 @@ describe Statsd do
     end
   end
 
+  describe "#batch" do
+    it "should yield itself" do
+      @statsd.batch { |s|
+        s.must_equal @statsd
+      }
+    end
+  end
+
   describe "with namespace" do
     before { @statsd.namespace = 'service' }
 


### PR DESCRIPTION
Many other existing, popular libraries use the batch functionality of the original statsd-ruby. This method just adds a simple yield for compatibility with those libraries. Buffering will just be transparently used if enabled.
