### PR TITLE
Support literal IPv6 addresses

### DIFF
--- a/lib/github/statsd.rb
+++ b/lib/github/statsd.rb
@@ -19,7 +19,7 @@ module GitHub
       attr_reader :sock
 
       def initialize(address, port = nil)
-        address, port = address.split(':') if address.include?(':')
+        address, port = address.split(':') if address.count(':') == 1
         addrinfo = Addrinfo.ip(address)
 
         @sock = UDPSocket.new(addrinfo.pfamily)

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -21,6 +21,17 @@ describe GitHub::Statsd do
       statsd = GitHub::Statsd.new(FakeUDPSocket)
       statsd.client_class.must_equal FakeUDPSocket
     end
+
+    it "should allow literal IPv6 addresses" do
+      [
+        '0000:0000:0000:0000:0000:0000:0000:0001',
+        '::1'
+      ].each do |ipv6_addr|
+        statsd = GitHub::Statsd.new
+        statsd.add_shard ipv6_addr, 8125
+        statsd.shards.first.sock.addr[0].must_equal 'AF_INET6'
+      end
+    end
   end
 
   describe "#increment" do


### PR DESCRIPTION
Splitting an address by semicolons doesn't work properly for IPv6 addresses which usually use semicolons as the (double) octet separator. However, an IPv6 address will contain at least 2 semicolons, so this simple change should allow existing stuff to continue working.

However, it doesn't support the case where the address is IPv6 literal and also contains a port. However, in that Addrinfo also doesn't work, so I'm not sure how legitimate that case is.