### PR TITLE
Add `distribution` method

### DIFF
--- a/lib/github/statsd.rb
+++ b/lib/github/statsd.rb
@@ -91,6 +91,7 @@ module GitHub
     TIMING_TYPE = "ms".freeze
     GAUGE_TYPE = "g".freeze
     HISTOGRAM_TYPE = "h".freeze
+    DISTRIBUTION_TYPE = "d".freeze
 
     def initialize(client_class = nil)
       @shards = []
@@ -187,6 +188,11 @@ module GitHub
     # statsd server then uses the sample_rate to correctly track the average
     # for the stat.
     def histogram(stat, value, sample_rate=1); send stat, value, HISTOGRAM_TYPE, sample_rate end
+    
+    # A modified gauge that submits a distribution of values over a sample period.
+    # Arithmetic and statistical calculations (percetiles, average, etc.) on the data set
+    # are peformed server side rather than client side like a histogram.
+    def distribution(stat, value, sample_rate=1); send stat, value, DISTRIBUTION_TYPE, sample_rate end
 
     private
     def sampled(sample_rate)

--- a/spec/statsd_spec.rb
+++ b/spec/statsd_spec.rb
@@ -68,6 +68,13 @@ describe GitHub::Statsd do
     end
   end
 
+  describe "#distribution" do
+    it "should format the message according to the statsd spec" do
+      @statsd.distribution('foobar', 500)
+      @statsd.shards.first.recv.must_equal ["foobar:500|d"]
+    end
+  end
+
   describe "#time" do
     it "should format the message according to the statsd spec" do
       @statsd.time('foobar') { sleep(0.001); 'test' }


### PR DESCRIPTION
The distribution metric type is available under `beta` on datadog, which we have enabled on our account: https://docs.datadoghq.com/developers/dogstatsd/data_types/#distributions

They are more accurate than datadog's histogram metric, which aggregates on the client before sending them to the server, rendering it pretty useless when running quantiles or averages.

The `distribution` metric is computed server side, giving results that generally make much more sense.